### PR TITLE
fix: _printf with empty format specifier

### DIFF
--- a/get_print_function.c
+++ b/get_print_function.c
@@ -16,7 +16,8 @@ int (*get_print_function(char c))(va_list)
 	data optiontype[] = {
 		{"c", print_char}, {"s", print_string}, {"d", print_int},
 		{"i", print_int}, {"u", print_unsigned_int},
-		{"%", print_percentage}, {NULL, NULL}
+		{"%", print_percentage}, {" ", output_error},
+		{"\0", output_error}, {NULL, zero}
 	};
 
 	i = 0;
@@ -26,5 +27,5 @@ int (*get_print_function(char c))(va_list)
 			return (optiontype[i].functiontype);
 		i++;
 	}
-	return (zero);
+	return (0);
 }

--- a/holberton.h
+++ b/holberton.h
@@ -4,6 +4,7 @@
 #include <stdarg.h>
 #include <unistd.h>
 
+
 int _putchar(char c);
 int _printf(const char * const format, ...);
 int (*get_print_function(char c))(va_list);
@@ -12,8 +13,10 @@ int print_string(va_list value);
 int print_int(va_list value);
 int print_unsigned_int(va_list value);
 int print_percentage(va_list value);
-int zero();
-/**
+int zero(void);
+int output_error(void);
+
+/*
  * struct type - struct of type of data
  * @type: type od data
  * @functiontype: pointer to de function

--- a/output_error.c
+++ b/output_error.c
@@ -1,0 +1,11 @@
+#include "holberton.h"
+
+/**
+ * output_error - returns -1
+ *
+ * Return: -1
+ */
+int output_error(void)
+{
+	return (-1);
+}

--- a/printf.c
+++ b/printf.c
@@ -8,7 +8,8 @@
 int _printf(const char * const format, ...)
 {
 	va_list parameters;
-	unsigned int i, bytes, func;
+	unsigned int i, bytes;
+	int func;
 
 	if (!format)
 		return (-1);
@@ -20,7 +21,12 @@ int _printf(const char * const format, ...)
 		if (format[i] == '%')
 		{
 			func = get_print_function(format[i + 1])(parameters);
-			if (func)
+			if (func == -1)
+			{
+				va_end(parameters);
+				return (-1);
+			}
+			else if (func)
 			{
 				bytes += func;
 				i = i + 2;


### PR DESCRIPTION
Fixed bug where function didn't stop where a empty format specifier was
provided.