### PR TITLE
fix: null and wrong size return on print_rev

### DIFF
--- a/print_custom.c
+++ b/print_custom.c
@@ -60,6 +60,11 @@ int print_rev(va_list value)
 	char *reversed;
 	int i, len;
 
+	if (s == NULL)
+	{
+		write(1, "(null)", 6);
+		return(6);
+	}
 	len = _strlen(s);
 
 	reversed = malloc(sizeof(char) * len);
@@ -74,5 +79,5 @@ int print_rev(va_list value)
 
 	write(1, reversed, i);
 	free(reversed);
-	return(i);
+	return (i - 1);
 }


### PR DESCRIPTION
Fixed segfault when trying to print (null) with the %r format
specificator.

Fixed wrong size return of print_rev.